### PR TITLE
Aggregate statistics

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -19,6 +19,7 @@ $pathwayLightGrey: #f5f5f5;
 @import "question";
 @import "targets";
 @import "home";
+@import "heatmap";
 
 .odi-orange {
   .page-title, .site-title .status {

--- a/app/assets/stylesheets/heatmap.scss
+++ b/app/assets/stylesheets/heatmap.scss
@@ -1,0 +1,98 @@
+// HEATMAP
+
+.heatmap {
+
+ margin-bottom: 30px;
+
+ .heatmapHeader {
+  h2 {margin-bottom: 20px; float: left;}
+   span.glyphicon {color: $odiGrey;}
+  .activityColLabel {width: 30%; float: left; font-weight: 600; font-size: 14px}
+  .scoresLabels {width: 70%; float: left; font-weight: 600;
+   p.scoreColLabel {float: left; width: 20%; font-weight: 600; font-size: 14px; border-left: 10px solid white}
+  }
+ }
+
+  .theme {
+    border-top: 5px solid white;
+    background: #f5f5f5;
+    h2 {
+      padding: 15px 0 0 15px;
+      margin: 0 0 15px 0;
+      float: left;
+      width: 30%;
+      font-size: 18px;
+    }
+  }
+  ul.heatmapResults {
+   width: 70%;
+   float: left;
+   margin: 0;
+   padding: 0;
+
+   li {
+    width: 20%;
+    float: left;
+    list-style: none;
+    height: 50px;
+    display: inline-block;
+    a {
+     line-height: 50px;
+     display: block;
+     width: 100%;
+     height: 50px;
+     span.hide {visibility: none;}
+     }
+
+    // ranking - low. testing different colour combos
+    &.none       {background: #f5f5f5; border-left: 5px solid white;}
+    &.v-low      {background: transparentize($odiOrange, 0.8); border-left: 5px solid white;}
+    &.low        {background: transparentize($odiOrange, 0.6); border-left: 5px solid white;}
+    &.medium     {background: transparentize($odiOrange, 0.4); border-left: 5px solid white;}
+    &.high       {background: transparentize($odiOrange, 0.2); border-left: 5px solid white;}
+    &.v-high     {background: transparentize($odiOrange, 0); border-left: 5px solid white;}
+
+    .tooltip {
+       text-align: left !important;
+       .tooltip-inner {
+        max-width: 250px;
+        /* If max-width does not work, try using width instead */
+        width: 250px;
+       }
+       p {
+        text-align: left;
+        &:first-child {padding-top: 0.5em;}
+        font-size: 14px;
+        line-height: 1.2em;       
+       }
+       em { line-height: 1.25em; font-size: 2.2em; margin-right: 0.25em; float: left; position: relative; top: -0.15em;}
+       }
+   }
+  }
+
+
+   ul.legend {
+     padding: 0;
+     margin: 2em 0;
+     float: right;
+      font-size: 14px;
+   li {
+    display: inline-block;
+    list-style: none;
+    margin-right: 2em;
+    &:last-child {margin-right: 0;}
+
+    span {width: 1em; height: 1em; margin-right: 0.5em; display: inline-block;}
+
+    // ranking - low. testing different colour combos
+    &.none span {background: #f5f5f5; border: 1px solid $odiGreyLight;}
+    &.v-low span {background: transparentize($odiOrange, 0.8);}
+    &.low span {background: transparentize($odiOrange, 0.6);}
+    &.medium span {background: transparentize($odiOrange, 0.4);}
+    &.high span {background: transparentize($odiOrange, 0.2);}
+    &.v-high span {background: transparentize($odiOrange, 0);}
+
+   }
+  }
+
+}

--- a/app/controllers/statistics_controller.rb
+++ b/app/controllers/statistics_controller.rb
@@ -1,0 +1,8 @@
+class StatisticsController < ApplicationController
+  
+  def index
+    @dimensions = Questionnaire.current.dimensions
+    @scorer = OrganisationScorer.new
+  end
+        
+end

--- a/app/helpers/statistics_helper.rb
+++ b/app/helpers/statistics_helper.rb
@@ -1,0 +1,11 @@
+module StatisticsHelper
+
+  def heatmap_colour(value)
+    ["none", "v-low", "low", "medium", "high", "v-high"][value]
+  end
+   
+  def percentage(count, results)
+    return count / results[:completed] * 100
+  end
+   
+end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,10 +1,15 @@
 class Organisation < ActiveRecord::Base
 
+  has_many :users
+  has_many :organisation_scores, dependent: :destroy
+  
   validates :title, presence: true
   validates :title, uniqueness: true
 
   before_save :set_name
 
+
+    
   def to_s
     self.title
   end
@@ -17,4 +22,18 @@ class Organisation < ActiveRecord::Base
     self.name = self.title.parameterize if self.name.blank?
   end
 
+  def parent?
+    Organisation.where(parent: self.id).present?
+  end
+  
+  def dgu_organisation?
+    return dgu_id.present?
+  end
+  
+  def latest_completed_assessment
+    user = users.first
+    return nil unless user.present?
+    return user.assessments.where("completion_date is not null").order(completion_date: :desc).first
+  end  
+  
 end

--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -1,7 +1,6 @@
 class Organisation < ActiveRecord::Base
 
   has_many :users
-  has_many :organisation_scores, dependent: :destroy
   
   validates :title, presence: true
   validates :title, uniqueness: true

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -10,7 +10,7 @@
 
   <div class="form-group">
     <%= f.label :name %><br />
-    <%= f.text_field :name, "data-validation": "required", "data-validation-error-msg": t(:enter_name) %>
+    <%= f.text_field :name, "data-validation": "required", "data-validation-error-msg": t(:name_validation) %>
   </div>
 
   <div class="form-group">

--- a/app/views/layouts/_footer.html.erb
+++ b/app/views/layouts/_footer.html.erb
@@ -1,7 +1,7 @@
 <footer class="site-footer">
     <div class="container">
         <div class="row">
-            <div class="col-md-8 footer-content">
+            <div class="col-md-7 footer-content">
                 <h1 class="footer-logo"><a href="http://www.theodi.org">Open Data Institute</a></h1>
                 <p><a href="http://www.theodi.org/contact">Open Data Institute, 65 Clifton Street, London EC2A 4JE</a></p>
                 <p><a href="mailto:info@theodi.org">info@theodi.org</a> Company <a href="http://opencorporates.com/companies/gb/08030289">08030289</a>
@@ -13,9 +13,10 @@
                     </a>
                 </p>
             </div>
-            <div class="col-md-4 footer-nav">
+            <div class="col-md-5 footer-nav">
                 <nav>
                     <ul class="pull-right list-inline">
+                        <li><a href="/statistics">Statistics</a></li>
                         <li><a href="/terms-of-use">Terms of use</a></li>
                         <li><a href="/privacy-policy">Privacy policy</a></li>
                         <li><a href="/cookie-policy">Cookie policy</a></li>

--- a/app/views/statistics/_organisations_tab.html.erb
+++ b/app/views/statistics/_organisations_tab.html.erb
@@ -14,7 +14,7 @@
     </div>
 
     <% if results[:completed] == 0 %>
-      <p>None of the <%= pluralize(results[:children], "organisation") %> have completed an assessment</p>
+      <p>None of the organisations have completed an assessment</p>
     <% else %>
   
       <p>Showing aggregate results for <%= pluralize( results[:completed], "assessment") %> from a total of <%= results[:children] %> organisations.</p>

--- a/app/views/statistics/_organisations_tab.html.erb
+++ b/app/views/statistics/_organisations_tab.html.erb
@@ -1,0 +1,67 @@
+<section class="heatmap clearfix">
+  <header class="heatmapHeader clearfix">
+    <div class="clearfix">
+      <h2>Ratings for <%= title %></h2>
+
+      <ul class="legend">
+        <li class="none"><span><a href="#"></a></span>None</li>
+        <li class="v-low"><span><a href="#"></a></span>Very low</li>
+        <li class="low"><span><a href="#"></a></span>Low</li>
+        <li class="medium"><span><a href="#"></a></span>Medium</li>
+        <li class="high"><span><a href="#"></a></span>High</li>
+        <li class="v-high"><span><a href="#"></a></span>Very High</li>
+      </ul>
+    </div>
+
+    <% if results[:completed] == 0 %>
+      <p>None of the <%= pluralize(results[:children], "organisation") %> have completed an assessment</p>
+    <% else %>
+  
+      <p>Showing aggregate results for <%= pluralize( results[:completed], "assessment") %> from a total of <%= results[:children] %> organisations.</p>
+  
+      <%= render 'assessments/activity_label' %>
+    
+      <div class="scoresLabels clearfix">
+        <p class="scoreColLabel">1 - Initial <span class="glyphicon glyphicon-info-sign" aria-hidden="true" 
+              data-toggle="tooltip" data-placement="top" title="maturity score"></span></p>
+        <p class="scoreColLabel">2 - Repeatable <span class="glyphicon glyphicon-info-sign" aria-hidden="true" 
+              data-toggle="tooltip" data-placement="top" title="maturity score"></span></p>
+        <p class="scoreColLabel">3 - Defined <span class="glyphicon glyphicon-info-sign" aria-hidden="true" 
+              data-toggle="tooltip" data-placement="top" title="maturity score"></span></p>
+        <p class="scoreColLabel">4 - Managed <span class="glyphicon glyphicon-info-sign" aria-hidden="true" 
+              data-toggle="tooltip" data-placement="top" title="maturity score"></span></p>
+        <p class="scoreColLabel">5 - Optimising <span class="glyphicon glyphicon-info-sign" aria-hidden="true"
+              data-toggle="tooltip" data-placement="top" title="maturity score"></span></p>
+      </div>
+    <% end %>
+  </header>
+
+  <% if results[:completed] > 0 %>
+    <% normalised_results = @scorer.normalise_counts(results) %>
+  
+    <% for dimension in @dimensions %>
+      <div class="theme clearfix">
+        <h2><strong><%= dimension.title %></strong></h2>
+      </div>
+
+      <% dimension.activities.each do |activity | %>
+        <div class="theme clearfix">
+          <h2><%= activity.title %></h2>
+           <ul class="heatmapResults clearfix">
+
+            <% activity_scores = results[:activities][activity.name] %>
+            <% normalised_scores = normalised_results[:activities][activity.name] %>
+            <% normalised_scores.each_with_index do |bin, index| %>            
+              <li class="score-<%= index + 1 %> <%= heatmap_colour(bin) %>">
+               <a href="#" title="<p><em><%= percentage(activity_scores[index], results) %>%</em>of organisations scored <%= index + 1 %> for <%= activity.title %>.</p> <p><%= activity_scores[index] %> out of a total <%= results[:completed] %> responses</p>" data-html="true" rel="tooltip">
+                <span class="hide"><%= percentage(activity_scores[index], results) %>% of organisations scored <%= index + 1 %> for <%= activity.title %>. <%= activity_scores[index] %> out of a total <%= results[:completed] %> responses</span></a>
+              </li>
+            <% end %>
+          </ul>
+          
+        </div>
+      <% end %>
+      
+    <% end %>
+  <% end %>    
+</section>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -1,0 +1,48 @@
+<% content_for :title do %>Statistics<% end %>
+
+<div id="mainContent" class="container">
+
+  <div class="tabbable boxed parentTabs">
+    <!-- Nav tabs -->
+    <ul id="statisticsNav" class="nav nav-tabs" role="tablist">
+      <li role="presentation" class="active">
+        <a href="#organisationTab" role="tab" data-toggle="tab">All organisations</a>
+      </li>
+      <li role="presentation">
+        <a href="#dguTab" role="tab" data-toggle="tab">All data.gov.uk organisations</a>
+      </li>
+         
+      <% if current_user && (current_user.organisation.present? && current_user.organisation.parent.present?) %>
+      <li role="presentation">
+        <a href="#networkTab" role="tab" data-toggle="tab">All in your parent organisation</a>
+      </li>
+      <% end %>
+        
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">    
+      <div role="tabpanel" class="tab-pane fade active in" id="organisationTab">
+        <%= render 'organisations_tab', title: "all organisations", 
+            scorer: @scorer, results: @scorer.score_all_organisations %>
+      </div>
+      <div role="tabpanel" class="tab-pane fade in" id="dguTab">
+        <%= render 'organisations_tab', title: "all data.gov.uk organisations", 
+            scorer: @scorer, results: @scorer.score_dgu_organisations %>
+      </div>
+      <% if current_user && (current_user.organisation.present? && current_user.organisation.parent.present?) %>
+      <div role="tabpanel" class="tab-pane fade in" id="networkTab">
+        <%= render 'organisations_tab', title: "all peer organisations", 
+            scorer: @scorer, results: @scorer.score_children( current_user.organisation ) %>
+      </div>
+      <% end %>
+    </div>
+    <!-- end tab panes -->
+  </div>
+</div>
+
+<% content_for :javascript_footer do %>
+     $('.heatmapResults').tooltip({
+       selector: "a[rel=tooltip]"
+     })
+<% end %>

--- a/app/views/statistics/index.html.erb
+++ b/app/views/statistics/index.html.erb
@@ -33,7 +33,7 @@
       <% if current_user && (current_user.organisation.present? && current_user.organisation.parent.present?) %>
       <div role="tabpanel" class="tab-pane fade in" id="networkTab">
         <%= render 'organisations_tab', title: "all peer organisations", 
-            scorer: @scorer, results: @scorer.score_children( current_user.organisation ) %>
+            scorer: @scorer, results: @scorer.score_children( Organisation.find( current_user.organisation.parent ) ) %>
       </div>
       <% end %>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,6 +29,8 @@ Rails.application.routes.draw do
   get '/cookie-policy' => 'high_voltage/pages#show', id: 'cookie_policy'
   get '/about' => 'high_voltage/pages#show', id: 'about'
     
+  get '/statistics' => 'statistics#index'
+  
   # The priority is based upon order of creation: first created -> highest priority.
   # See how all your routes lay out with "rake routes".
 

--- a/features/home.feature
+++ b/features/home.feature
@@ -7,6 +7,7 @@ Feature: Home page
     And I should see a link called "Terms of use" to "/terms-of-use"
     And I should see a link called "Sign in" to "/users/sign_in"
     And I should see a link called "Register" to "/users/sign_up" 
+    And I should see a link called "Statistics" to "/statistics"
 
   Scenario: Viewing the home page as a user
     Given I am logged in as a user

--- a/features/statistics.feature
+++ b/features/statistics.feature
@@ -3,7 +3,7 @@ Feature: Statistics page
   Scenario: There are no completed organisational assessments
     Given the test survey has been loaded  
     When I go to "/statistics"
-    Then I should see "None of the 0 organisations have completed an assessment"
+    Then I should see "None of the organisations have completed an assessment"
     
   Scenario: Viewing organisational assessments as an anonymous user
     Given the test survey has been loaded

--- a/features/statistics.feature
+++ b/features/statistics.feature
@@ -1,0 +1,23 @@
+Feature: Statistics page
+
+  Scenario: There are no completed organisational assessments
+    Given the test survey has been loaded  
+    When I go to "/statistics"
+    Then I should see "None of the 0 organisations have completed an assessment"
+    
+  Scenario: Viewing organisational assessments as an anonymous user
+    Given the test survey has been loaded
+    Given there is an organisation user
+    Given the following assessments:
+      | title   | notes              | start_date          | completion_date | user_id | completed |
+      | 2014 Q4 | End of last year   | 2014-12-10 11:07:10 |                 | 1       | yes       |
+      | 2015 Q1 | Start of year      | 2015-02-10 11:07:10 |                 | 1       | yes       |
+    When I go to "/statistics"
+    Then I should see "All organisations"
+    Then I should see "All data.gov.uk organisations"
+    Then I should not see "All in your parent organisation"
+    Then I should see "Ratings for all organisations"
+    Then I should see "Showing aggregate results for 1 assessment from a total of 1 organisation"
+    Then I should see "Data release process"
+    Then I should see "100% of organisations scored 1 for Data release process"
+        

--- a/features/statistics.feature
+++ b/features/statistics.feature
@@ -21,3 +21,21 @@ Feature: Statistics page
     Then I should see "Data release process"
     Then I should see "100% of organisations scored 1 for Data release process"
         
+  Scenario: Viewing organisational assessments as d.g.u organisational user
+    Given the test survey has been loaded
+    Given there is a hierarchy of data.gov.uk organisations    
+    Given the following assessments:
+      | title   | notes              | start_date          | completion_date | user_id | completed |
+      | 2014 Q4 | End of last year   | 2014-12-10 11:07:10 |                 | 1       | yes       |
+      | 2015 Q1 | Start of year      | 2015-02-10 11:07:10 |                 | 2       | yes       |
+    When I am logged in as the forestry commission
+    And I go to "/statistics"
+    Then I should see "All organisations"
+    Then I should see "All data.gov.uk organisations"
+    Then I should see "All in your parent organisation"
+    Then I should see "Ratings for all organisations"
+    Then I should see "Ratings for all peer organisations"
+    Then I should see "Showing aggregate results for 2 assessments from a total of 3 organisations"
+    Then I should see "Data release process"
+    Then I should see "100% of organisations scored 1 for Data release process"        
+        

--- a/features/step_definitions/assessment_steps.rb
+++ b/features/step_definitions/assessment_steps.rb
@@ -1,7 +1,12 @@
 Given(/^the following assessments:$/) do |table|
   table.hashes.each do |attributes|
-    attributes.merge!(user_id: @current_user.id)
-    FactoryGirl.create(:assessment, attributes)
+    attributes.merge!(user_id: @current_user.id) unless attributes[:user_id].present?
+    complete = attributes.delete("completed")
+    assessment = FactoryGirl.create(:assessment, attributes)
+    if complete == "yes"
+      AssessmentAnswer.create( assessment: assessment, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      assessment.complete
+    end
   end
 end
 

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -22,8 +22,25 @@ Given(/^I am logged in as a user$/) do
   
 end
 
+Given(/^I am logged in as an organisation user$/) do
+  
+  user =  FactoryGirl.create(:organisation_user)
+  @current_user = user
+  
+  visit '/users/sign_in'
+  fill_in "user_email", :with => user.email
+  fill_in "user_password", :with => user.password
+  click_button "Sign in"
+  
+end
+
 Given(/^there is a registered user$/) do
   FactoryGirl.create(:user)
+end
+
+Given(/^there is an organisation user$/) do
+  FactoryGirl.create(:organisation)
+  FactoryGirl.create(:organisation_user)
 end
 
 

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -43,4 +43,25 @@ Given(/^there is an organisation user$/) do
   FactoryGirl.create(:organisation_user)
 end
 
+Given(/^there is a hierarchy of data.gov.uk organisations$/) do
+  #1
+  defra = FactoryGirl.create(:organisation)
+  #2
+  ea = FactoryGirl.create(:organisation, title: "Environment Agency", parent: 1)
+  #3
+  fc = FactoryGirl.create(:organisation, title: "Forestry Commission", parent: 1)
+  
+  FactoryGirl.create(:organisation_user, organisation_id: 2)
+  @fc_user = FactoryGirl.create(:organisation_user, email: "another@example.org", organisation_id: 3)  
+end
 
+Given(/^I am logged in as the forestry commission$/) do
+  
+  @current_user = @fc_user
+  
+  visit '/users/sign_in'
+  fill_in "user_email", :with => @fc_user.email
+  fill_in "user_password", :with => @fc_user.password
+  click_button "Sign in"
+  
+end

--- a/features/step_definitions/authentication_steps.rb
+++ b/features/step_definitions/authentication_steps.rb
@@ -39,20 +39,20 @@ Given(/^there is a registered user$/) do
 end
 
 Given(/^there is an organisation user$/) do
-  FactoryGirl.create(:organisation)
-  FactoryGirl.create(:organisation_user)
+  org = FactoryGirl.create(:organisation)
+  FactoryGirl.create(:organisation_user, organisation_id: org.id)
 end
 
 Given(/^there is a hierarchy of data.gov.uk organisations$/) do
   #1
   defra = FactoryGirl.create(:organisation)
   #2
-  ea = FactoryGirl.create(:organisation, title: "Environment Agency", parent: 1)
+  ea = FactoryGirl.create(:organisation, title: "Environment Agency", parent: defra.id)
   #3
-  fc = FactoryGirl.create(:organisation, title: "Forestry Commission", parent: 1)
+  fc = FactoryGirl.create(:organisation, title: "Forestry Commission", parent: defra.id)
   
-  FactoryGirl.create(:organisation_user, organisation_id: 2)
-  @fc_user = FactoryGirl.create(:organisation_user, email: "another@example.org", organisation_id: 3)  
+  FactoryGirl.create(:organisation_user, organisation_id: ea.id)
+  @fc_user = FactoryGirl.create(:organisation_user, email: "another@example.org", organisation_id: fc.id)  
 end
 
 Given(/^I am logged in as the forestry commission$/) do

--- a/lib/organisation_scorer.rb
+++ b/lib/organisation_scorer.rb
@@ -34,13 +34,16 @@ class OrganisationScorer
   end  
 
   def normalise_counts(results, bins=5)
-    bin_size = results[:completed] / bins
-    normalised = {}
+    bin_size = results[:completed].to_f / bins.to_f
+    normalised = {
+      activities: {},
+      children: results[:children],
+      completed: results[:completed]
+    }
     results[:activities].each do |name, counts|
-    normalised[name] = counts.map { |c| c == 0 ? 0 : (c.to_f / bin_size).ceil}
+      normalised[:activities][name] = counts.map { |c| c == 0 ? 0 : (c.to_f / bin_size).ceil}
     end
-    results[:activities] = normalised
-    results
+    normalised
   end
   
   

--- a/lib/organisation_scorer.rb
+++ b/lib/organisation_scorer.rb
@@ -1,0 +1,47 @@
+class OrganisationScorer
+  
+  def score_all_organisations
+    score_organisations( Organisation.all )
+  end
+  
+  def score_dgu_organisations
+    score_organisations( Organisation.where("dgu_id is not null") )
+  end
+
+  def score_children(organisation)
+    score_organisations( Organisation.where("parent = ?", organisation.id) )
+  end  
+  
+  def score_organisations(organisations)
+    results = {
+      activities: {},
+      children: organisations.size,
+      completed: 0  
+    }    
+    Questionnaire.current.activities.each do |activity|
+      results[:activities][activity.name] = [0,0,0,0,0]
+    end
+    organisations.each do |organisation|
+      assessment = organisation.latest_completed_assessment
+      if assessment.present?
+        results[:completed] += 1
+        assessment.scores.each do |score|
+          results[:activities][score.activity.name][score.score - 1 ] += 1
+        end
+      end
+    end
+    return results
+  end  
+
+  def normalise_counts(results, bins=5)
+    bin_size = results[:completed] / bins
+    normalised = {}
+    results[:activities].each do |name, counts|
+    normalised[name] = counts.map { |c| c == 0 ? 0 : (c.to_f / bin_size).ceil}
+    end
+    results[:activities] = normalised
+    results
+  end
+  
+  
+end

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -14,4 +14,13 @@ FactoryGirl.define do
     encrypted_password Devise.bcrypt(User, 'otherpassword')
     admin true
   end
+  
+  factory :organisation_user, class: User do
+    name "Peter Manion"
+    email "user@example.org"
+    password 'somepassword'
+    encrypted_password Devise.bcrypt(User, 'somepassword')
+    organisation_id 1
+  end
+  
 end

--- a/spec/lib/organisation_scorer_spec.rb
+++ b/spec/lib/organisation_scorer_spec.rb
@@ -153,6 +153,22 @@ describe OrganisationScorer do
       expect( normalised[:activities]["governance"] ).to eql([1,4,2,0,0]) 
     end  
     
+    it "should normalise correctly" do
+      results = {
+        activities: {
+          "data-management-processes" => [1, 0, 0, 0, 0],
+          "standards" => [0, 0, 0, 0, 0]
+        },
+        children: 1000,
+        completed: 1  
+      }  
+      normalised = scorer.normalise_counts(results)
+      expect( normalised[:children] ).to eql(1000)
+      expect( normalised[:completed] ).to eql(1)
+      expect( normalised[:activities]["data-management-processes"] ).to eql([5,0,0,0,0]) 
+      expect( normalised[:activities]["standards"] ).to eql([0,0,0,0,0]) 
+    end      
+    
   end
   
 end

--- a/spec/lib/organisation_scorer_spec.rb
+++ b/spec/lib/organisation_scorer_spec.rb
@@ -1,0 +1,158 @@
+require 'spec_helper'
+require 'organisation_scorer'
+require 'questionnaire_importer'
+require 'progress_calculator'
+
+describe OrganisationScorer do
+
+  before(:each) do
+    config = File.join( __dir__, "test-survey.xls" )    
+    QuestionnaireImporter.load(1, config)    
+  end
+  
+  context ".score_organisations" do
+    let!(:organisation) { FactoryGirl.create :organisation }
+    let!(:user) { FactoryGirl.create :organisation_user }
+    let!(:assessment) { FactoryGirl.create :assessment, user: user }
+    let!(:scorer) { OrganisationScorer.new }
+  
+    before(:each) {
+      AssessmentAnswer.create( assessment: assessment, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      assessment.complete
+    }
+    
+    it "should return organisation count" do
+      expect( scorer.score_organisations( Organisation.all )[:children] ).to eql(1)
+    end
+    
+    it "should return number of completed assessments" do
+      expect( scorer.score_organisations( Organisation.all )[:completed] ).to eql(1)      
+    end
+    it "should score all activities" do
+      expect( scorer.score_organisations(Organisation.all)[:activities].keys.size ).to eql(Activity.all.count)
+    end
+    
+    it "should count totals for an activity" do
+      scores = scorer.score_organisations(Organisation.all)[:activities]
+      expect( scores[ Activity.first.name ][0] ).to eql(1) 
+      expect( scores[ Activity.first.name ][1] ).to eql(0)   
+    end
+          
+    it "should only count completed assessments" do
+      ua = FactoryGirl.create :unfinished_assessment, user: user
+      AssessmentAnswer.create( assessment: ua, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      results = scorer.score_organisations( Organisation.all )
+      expect( results[:completed] ).to eql(1)        
+      expect( results[:activities][Activity.first.name][0]).to eql(1)
+    end
+    
+  end
+  
+  context ".score_all_organisations" do
+
+    let!(:organisation) { FactoryGirl.create :organisation }
+    let!(:user) { FactoryGirl.create :organisation_user }
+    let!(:assessment) { FactoryGirl.create :assessment, user: user }
+    let!(:scorer) { OrganisationScorer.new }
+  
+    before(:each) {
+      AssessmentAnswer.create( assessment: assessment, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      assessment.complete
+    }
+        
+    it "should count all organisations" do
+      org = FactoryGirl.create :organisation, title: "other"
+      u = FactoryGirl.create :user, organisation: org, email: "other@example.org"
+      a = FactoryGirl.create :assessment, user: u
+      AssessmentAnswer.create( assessment: a, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      a.complete
+      results = scorer.score_all_organisations
+      expect( results[:children] ).to eql(2)
+      expect( results[:completed] ).to eql(2)
+      expect( results[:activities][ Activity.first.name ][0] ).to eql(2)
+    end
+
+  end
+  
+  context ".score_dgu_organisations" do
+
+    let!(:organisation) { FactoryGirl.create :organisation }
+    let!(:user) { FactoryGirl.create :organisation_user }
+    let!(:assessment) { FactoryGirl.create :assessment, user: user }
+    let!(:scorer) { OrganisationScorer.new }
+  
+    before(:each) {
+      AssessmentAnswer.create( assessment: assessment, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      assessment.complete
+    }
+        
+    it "should count only d.g.u organisations" do
+      #this one should be ignored
+      org = FactoryGirl.create :organisation, title: "other", dgu_id: nil
+      u = FactoryGirl.create :user, organisation: org, email: "other@example.org"
+      a = FactoryGirl.create :assessment, user: u
+      AssessmentAnswer.create( assessment: a, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      a.complete
+      results = scorer.score_dgu_organisations
+      expect( results[:children] ).to eql(1)
+      expect( results[:completed] ).to eql(1)
+      expect( results[:activities][ Activity.first.name ][0] ).to eql(1)
+    end
+
+      
+  end
+
+  context ".score_children" do      
+    let!(:parent_organisation) { FactoryGirl.create :organisation, title: "parent", dgu_id: nil }
+    let!(:organisation) { FactoryGirl.create :organisation, parent: parent_organisation.id }
+    let!(:user) { FactoryGirl.create :organisation_user, organisation: organisation }
+
+    let!(:assessment) { FactoryGirl.create :assessment, user: user }
+    let!(:scorer) { OrganisationScorer.new }
+  
+    before(:each) {
+      AssessmentAnswer.create( assessment: assessment, question: Question.first, answer: Answer.find_by_code("Q1.2") )
+      assessment.complete      
+    }
+
+    it "should score children" do
+      results = scorer.score_children(parent_organisation)
+      expect( results[:children] ).to eql(1)
+      expect( results[:completed] ).to eql(1)
+      expect( results[:activities][ Activity.first.name ][0] ).to eql(1)
+    end
+      
+    it "should score only those associated with the parent" do
+      organisation.parent = nil
+      organisation.save!
+      results = scorer.score_children(parent_organisation)
+      expect( results[:children] ).to eql(0)
+      expect( results[:completed] ).to eql(0)
+    end
+      
+  end
+  
+  context ".normalise_counts" do
+    let!(:scorer) { OrganisationScorer.new }
+      
+    it "should normalise to bins" do
+      results = {
+        activities: {
+          "data-management-processes" => [0, 3, 5, 6, 0],
+          "standards" => [0, 15, 0, 0, 0],
+          "governance" => [1, 10, 4, 0, 0]
+        },
+        children: 15,
+        completed: 15  
+      }  
+      normalised = scorer.normalise_counts(results)
+      expect( normalised[:children] ).to eql(15)
+      expect( normalised[:completed] ).to eql(15)
+      expect( normalised[:activities]["data-management-processes"] ).to eql([0,1,2,2,0]) 
+      expect( normalised[:activities]["standards"] ).to eql([0,5,0,0,0]) 
+      expect( normalised[:activities]["governance"] ).to eql([1,4,2,0,0]) 
+    end  
+    
+  end
+  
+end


### PR DESCRIPTION
Implement the initial version of the statistics page with basic heatmap.

Shows aggregrate results for all orgs, all d.g.u orgs, and within the users organisational network if the user is signed in and associated with an d.g.u org with a parent.

This covers #21, #27, #68 

Also fixed issue with the account edit page (#169)